### PR TITLE
RISC-V: enable F, D and A extensions

### DIFF
--- a/riscv/riscv64_isa.ac
+++ b/riscv/riscv64_isa.ac
@@ -27,6 +27,14 @@ AC_ISA(riscv){
   ac_format Type_R4 =
     "%rs3:5 %funct2:2 %rs2:5 %rs1:5 %funct3:3 %rd:5 %opcode:7";
 
+  // For F and D extensions
+  ac_format Type_Rfd =
+    "%funct5:5 %fmt:2 %rs2:5 %rs1:5 %rm:3 %rd:5 %opcode:7";
+
+  // For F and D extensions
+  ac_format Type_R4fd =
+    "%rs3:5 %fmt:2 %rs2:5 %rs1:5 %rm:3 %rd:5 %opcode:7";
+
   ac_format Type_I =
     "%imm:12 %rs1:5 %funct3:3 %rd:5 %opcode:7";
 
@@ -91,8 +99,23 @@ AC_ISA(riscv){
     "ft"[8..11] = [28..31];
   }
 
+  // Floating point rounding mode
+  // See RISC-V Unprivileged ISA,
+  //     Section 11.2 Floating-Point Control and Status Register
+  ac_asm_map rm {
+    "rne"    = 0; // Round to Nearest, ties to Even
+    "rtz"    = 1; // Round towards Zero
+    "rdn"    = 2; // Round Down (towards −Inf)
+    "rup"    = 3; // Round Up (towards +Inf)
+    "rmm"    = 4; // Round to Nearest, ties to Max Magnitude
+    "inv101" = 5; // Invalid, reserved.
+    "inv110" = 6; // Invalid, reserved.
+    "dyn"    = 7; // In instruction’s rm field: selects dynamic rounding mode,
+                 // In Rounding Mode register: invalid.
+  }
+
   /*
-   * RV65G is shorthand for the IMAFDZicsr Zifencei
+   * RV64G is shorthand for the IMAFDZicsr Zifencei
    */
   _ac_riscv_opcodes("riscv-opcodes/opcodes-system");
   _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32i");
@@ -101,16 +124,15 @@ AC_ISA(riscv){
   _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32m");
   _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64m");
 
+  _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32f");
+  _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64f");
+
+  _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32d");
+  _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64d");
+
   /*
    * Not yet supported
    */
   // _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32a");
   // _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64a");
-
-  // _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32f");
-  // _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64f");
-
-  // _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32d");
-  // _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64d");
-
 };

--- a/riscv/riscv64_isa.ac
+++ b/riscv/riscv64_isa.ac
@@ -31,6 +31,10 @@ AC_ISA(riscv){
   ac_format Type_Rfd =
     "%funct5:5 %fmt:2 %rs2:5 %rs1:5 %rm:3 %rd:5 %opcode:7";
 
+  // For A extension
+  ac_format Type_Ra =
+    "%funct5_h3:3 %funct5_l2:2 %aqrl:2 %rs2:5 %rs1:5 %funct3:3 %rd:5 %opcode:7";
+
   // For F and D extensions
   ac_format Type_R4fd =
     "%rs3:5 %fmt:2 %rs2:5 %rs1:5 %rm:3 %rd:5 %opcode:7";
@@ -114,6 +118,16 @@ AC_ISA(riscv){
                  // In Rounding Mode register: invalid.
   }
 
+  // Ordering of atomic instructions
+  // See RISC-V Unprivileged ISA,
+  //     Section 8.1 Specifying Ordering of Atomic Instructions
+  ac_asm_map aqrl {
+     ""      = 0; // No additional ordering constraints imposed
+     ".rl"   = 1; // Atomic memory operation is treated as a release access
+     ".aq"   = 2; // Atomic memory operation is treated as an acquire access
+     ".aqrl" = 3; // The atomic memory operation is sequentially consistent
+  }
+
   /*
    * RV64G is shorthand for the IMAFDZicsr Zifencei
    */
@@ -130,9 +144,6 @@ AC_ISA(riscv){
   _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32d");
   _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64d");
 
-  /*
-   * Not yet supported
-   */
-  // _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32a");
-  // _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64a");
+  _ac_riscv_opcodes("riscv-opcodes/opcodes-rv32a");
+  _ac_riscv_opcodes("riscv-opcodes/opcodes-rv64a");
 };

--- a/riscv/riscv64_isa.ac
+++ b/riscv/riscv64_isa.ac
@@ -1,12 +1,18 @@
 /*
-* @file		riscv_isa.cpp
-* @version	1.0
-* @author   Pavani Tripathi
+* @file         riscv_isa.cpp
+* @version      1.0
+* @author   Pavani Tripathi, Jan Vrany
 *
 * @date     May 2016
-* @brief 	The ArchC RISC-V functional model
+* @brief        The ArchC RISC-V functional model
 *
 * @source   http://people.eecs.berkeley.edu/~krste/papers/riscv-spec-2.0.pdf
+*
+* This file is has been refactored to use Pharo-ArchC [1] extensions to
+* allow reading instructions from riscv-opcodes [2].
+*
+* [1]: https://github.com/shingarov/Pharo-ArchC
+* [2]: https://github.com/riscv/riscv-opcodes
 */
 
 AC_ISA(riscv){


### PR DESCRIPTION
This PR enables F, D and A extensions in RISC-V PDL. This requires support in Pharo-ArchC
(see PR https://github.com/shingarov/Pharo-ArchC/pull/12)