### PR TITLE
Add PowerPC64 support

### DIFF
--- a/powerpc/powerpc64.ac
+++ b/powerpc/powerpc64.ac
@@ -1,0 +1,53 @@
+/**
+ * @file      powerpc64.ac
+ * @author    Jan Vrany
+ *
+ *            LabWare
+ *
+ * @version   1.0
+ * @date      Mon, 14 Nov 2022
+ * 
+ * @brief     The ArchC POWERPC64 functional model.
+ * 
+ * @attention Copyright (C) 2022-2022 --- LabWare
+ *
+ */
+
+AC_ARCH(powerpc64) {
+
+	ac_wordsize 64;
+
+	ac_mem MEM:512M;
+
+	ac_regbank GPR:32;
+
+	ac_reg SPRG4;
+	ac_reg SPRG5;
+	ac_reg SPRG6;
+	ac_reg SPRG7;
+	ac_reg USPRG0;
+
+	ac_reg XER;
+
+	ac_reg MSR;
+
+// sc instruction not tested/used
+	ac_reg EVPR;
+	ac_reg SRR0;
+	ac_reg SRR1;
+
+	ac_reg CR;
+	ac_reg LR;
+	ac_reg CTR;
+    ac_reg id;
+
+	ARCH_CTOR(powerpc64) {
+		ac_isa("powerpc_isa.ac");
+		ac_isa("powerpc64_isa.ac");
+        ac_gdb("powerpc.xml");
+
+        // PPC64le seems to be more common at least in
+        // Linux world.
+		set_endian("little");
+	};
+};

--- a/powerpc/powerpc64_isa.ac
+++ b/powerpc/powerpc64_isa.ac
@@ -61,6 +61,11 @@ AC_ISA(powerpc64) {
   ac_instr<DS3> std, stdu;
   ac_instr<X8> stdx, stdux;
 
+  /*
+   * See Section 3.3.13.1 64-bit Fixed-Point Logical Instructions
+   */
+  ac_instr<X13> extsw;
+
   ISA_CTOR(powerpc64) {
 
     td.set_asm("td %imm, %reg, %reg", to, ra, rb);
@@ -103,6 +108,12 @@ AC_ISA(powerpc64) {
     stdux.set_decoder(opcd=31, xog=181);
     stdux.set_asm("stdux %reg, %reg, %reg", rs, ra, rb);
 
+    /*
+     * See Section 3.3.13.1 64-bit Fixed-Point Logical Instructions
+     */
+    extsw.set_decoder(opcd=31, xog=986);
+    extsw.set_asm("extsw %reg, %reg", ra, rs, rc=0);
+    extsw.set_asm("extsw. %reg, %reg", ra, rs, rc=1);
 
   }; // ISA_CTOR(powerpc64)
 

--- a/powerpc/powerpc64_isa.ac
+++ b/powerpc/powerpc64_isa.ac
@@ -34,9 +34,32 @@
 
 AC_ISA(powerpc64) {
 
+  /*
+   * See Power ISA (Version 3.1.B), Section 1.6.1.5
+   */
+  ac_format DS1 = "%opcd:6 %frsp:5 %ra:5 %ds:14:s %xo:2";
+  ac_format DS2 = "%opcd:6 %frtp:5 %ra:5 %ds:14:s %xo:2";
+  ac_format DS3 = "%opcd:6 %rs:5   %ra:5 %ds:14:s %xo:2";
+  ac_format DS4 = "%opcd:6 %rsp:5  %ra:5 %ds:14:s %xo:2";
+  ac_format DS5 = "%opcd:6 %rt:5   %ra:5 %ds:14:s %xo:2";
+  ac_format DS6 = "%opcd:6 %vrs:5  %ra:5 %ds:14:s %xo:2";
+  ac_format DS7 = "%opcd:6 %vrt:5  %ra:5 %ds:14:s %xo:2";
+
   ac_instr<D7> tdi;
 
   ac_instr<X21> td;
+
+  /*
+   * See Section 3.3.2.1 64-bit Fixed-Point Load Instructions
+   */
+  ac_instr<DS5> ld, ldu;
+  ac_instr<X2> ldx, ldux;
+
+  /*
+   * See Section 3.3.3.1 64-bit Fixed-Point Store Instructions
+   */
+  ac_instr<DS3> std, stdu;
+  ac_instr<X8> stdx, stdux;
 
   ISA_CTOR(powerpc64) {
 
@@ -49,6 +72,37 @@ AC_ISA(powerpc64) {
     tdi.set_asm("td%[trapcond]i %reg, %imm", to, ra, si);
     tdi.set_decoder(opcd=2);
     tdi.set_cycles(1);
+
+    /*
+     * See Section 3.3.2.1 64-bit Fixed-Point Load Instructions
+     */
+    ld.set_decoder(opcd=58, xo=0);
+    ld.set_asm("ld %reg, %exp(bimm) (%reg)", rt, ds, ra);
+
+    ldu.set_decoder(opcd=58, xo=1);
+    ldu.set_asm("ldu %reg, %exp(bimm) (%reg)", rt, ds, ra);
+
+    ldx.set_decoder(opcd=31, xog=21);
+    ldx.set_asm("ldx %reg, %reg, %reg", rt, ra, rb);
+
+    ldux.set_decoder(opcd=31, xog=53);
+    ldux.set_asm("ldux %reg, %reg, %reg", rt, ra, rb);
+
+    /*
+     * See Section 3.3.3.1 64-bit Fixed-Point Store Instructions
+     */
+    std.set_decoder(opcd=62, xo=0);
+    std.set_asm("std %reg, %exp(bimm) (%reg)", rs, ds, ra);
+
+    stdu.set_decoder(opcd=62, xo=1);
+    stdu.set_asm("stdu %reg, %exp(bimm) (%reg)", rs, ds, ra);
+
+    stdx.set_decoder(opcd=31, xog=149);
+    stdx.set_asm("stdx %reg, %reg, %reg", rs, ra, rb);
+
+    stdux.set_decoder(opcd=31, xog=181);
+    stdux.set_asm("stdux %reg, %reg, %reg", rs, ra, rb);
+
 
   }; // ISA_CTOR(powerpc64)
 

--- a/powerpc/powerpc64_isa.ac
+++ b/powerpc/powerpc64_isa.ac
@@ -1,0 +1,55 @@
+/* ex: set tabstop=2 expandtab:
+   -*- Mode: C; tab-width: 2; indent-tabs-mode nil -*-
+*/
+/**
+ * @file      powerpc64_isa.ac
+ * @author    Jan Vrany
+ *
+ *            LabWare
+ *
+ * @version   1.0
+ * @date      Mon, 14 Nov 2022
+ *
+ * @brief     The ArchC POWERPC64 functional model.
+ *
+ * @attention Copyright (C) 2022-2022 --- LabWare
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/* Note: This file contains only instruction not present in 32bit PowerPC */
+
+AC_ISA(powerpc64) {
+
+  ac_instr<D7> tdi;
+
+  ac_instr<X21> td;
+
+  ISA_CTOR(powerpc64) {
+
+    td.set_asm("td %imm, %reg, %reg", to, ra, rb);
+    td.set_asm("td%[trapcond] %reg, %reg", to, ra, rb);
+    td.set_decoder(opcd=31, xog=68);
+    td.set_cycles(1);
+
+    tdi.set_asm("tdi %imm, %reg, %imm", to, ra, si);
+    tdi.set_asm("td%[trapcond]i %reg, %imm", to, ra, si);
+    tdi.set_decoder(opcd=2);
+    tdi.set_cycles(1);
+
+  }; // ISA_CTOR(powerpc64)
+
+}; // AC_ISA(powerpc64)

--- a/powerpc/powerpc_isa.ac
+++ b/powerpc/powerpc_isa.ac
@@ -19,6 +19,7 @@
  * @brief     The ArchC POWERPC functional model.
  * 
  * @attention Copyright (C) 2002-2006 --- The ArchC Team
+ *            Copyright (C) 2022-2022 --- LabWare
  * 
  * This program is free software; you can redistribute it and/or modify 
  * it under the terms of the GNU General Public License as published by 
@@ -100,7 +101,7 @@ AC_ISA(powerpc) {
 
   ac_instr<I1> b, ba, bl, bla;
 
-  ac_instr<B1> bc, bca, bcl, bcla;
+  ac_instr<B1> bc;
 
   ac_instr<SC1> sc;
 
@@ -214,6 +215,16 @@ AC_ISA(powerpc) {
     "lle", "lng" = 6;
     "lge", "lnl" = 5;
     "lgt"        = 1;
+  }
+
+  ac_asm_map aa {
+    ""  = 0;
+    "a" = 1;
+  }
+
+  ac_asm_map lk {
+    ""  = 0;
+    "l" = 1;
   }
 
 
@@ -361,22 +372,10 @@ AC_ISA(powerpc) {
     bla.set_decoder(opcd=18, aa=1, lk=1);
     bla.set_cycles(1); 
     
-    bc.set_asm("bc %imm, %exp, %addr(pcrel)", bo, bi, bd);
-    bc.set_decoder(opcd=16, aa=0, lk=0);
+    bc.set_asm("bc%[lk]%[aa] %imm, %exp, %addr(pcrel)", lk, aa, bo, bi, bd);
+    bc.set_decoder(opcd=16);
     bc.set_cycles(1); 
-    
-    bca.set_asm("bca %imm, %exp, %addr(pcrel)", bo, bi, bd);
-    bca.set_decoder(opcd=16, aa=1, lk=0);
-    bca.set_cycles(1); 
-    
-    bcl.set_asm("bcl %imm, %exp, %addr(pcrel)", bo, bi, bd);
-    bcl.set_decoder(opcd=16, aa=0, lk=1);
-    bcl.set_cycles(1); 
-    
-    bcla.set_asm("bcla %imm, %exp, %addr(pcrel)", bo, bi, bd);
-    bcla.set_decoder(opcd=16, aa=1, lk=1);
-    bcla.set_cycles(1); 
-    
+
     bcctr.set_asm("bctr", bo=0x14, bi=0, bh=0);
     bcctr.set_asm("bcctr %reg, %reg, %reg", bo, bi, bh);
     bcctr.set_decoder(opcd=19, xog=528, lk=0);
@@ -1212,18 +1211,6 @@ AC_ISA(powerpc) {
 
     bc.is_branch(ac_pc+(bd<<2));
     bc.cond(test_Branch_Cond(CR,CTR,bo,bi));
-
-    bca.is_branch(bd<<2);
-    bca.cond(test_Branch_Cond(CR,CTR,bo,bi));
-
-    bcl.is_branch(ac_pc+(bd<<2));
-    bcl.cond(test_Branch_Cond(CR,CTR,bo,bi));
-    bcl.behavior(LR.write(ac_pc+4););
-
-    bcla.is_branch(bd<<2);
-    bcla.cond(test_Branch_Cond(CR,CTR,bo,bi));
-    bcla.behavior(LR.write(ac_pc+4););
-
 
     bcctr.is_branch(CTR.read() & 0xFFFFFFFC);
     bcctr.cond(test_Branch_Cond(CR,CTR,bo,bi));

--- a/powerpc/powerpc_isa.ac
+++ b/powerpc/powerpc_isa.ac
@@ -160,9 +160,9 @@ AC_ISA(powerpc) {
                 subfc_, subfco, subfco_, subfe, subfe_, subfeo,
                 subfeo_;
 
-  ac_instr<D7> twi, tdi;
+  ac_instr<D7> twi;
 
-  ac_instr<X21> tw, td;
+  ac_instr<X21> tw;
 
 /*
 
@@ -1189,20 +1189,10 @@ AC_ISA(powerpc) {
     tw.set_decoder(opcd=31, xog=4);
     tw.set_cycles(1);
 
-    td.set_asm("td %imm, %reg, %reg", to, ra, rb);
-    td.set_asm("td%[trapcond] %reg, %reg", to, ra, rb);
-    td.set_decoder(opcd=31, xog=68);
-    td.set_cycles(1);
-
     twi.set_asm("twi %imm, %reg, %imm", to, ra, si);
     twi.set_asm("tw%[trapcond]i %reg, %imm", to, ra, si);
     twi.set_decoder(opcd=3);
     twi.set_cycles(1);
-
-    tdi.set_asm("tdi %imm, %reg, %imm", to, ra, si);
-    tdi.set_asm("td%[trapcond]i %reg, %imm", to, ra, si);
-    tdi.set_decoder(opcd=2);
-    tdi.set_cycles(1);
 
 
 /*******************************************************/

--- a/powerpc/powerpc_isa.ac
+++ b/powerpc/powerpc_isa.ac
@@ -43,7 +43,7 @@ AC_ISA(powerpc) {
 
   ac_format I1 = "%opcd:6 %li:24:s %aa:1 %lk:1";
 
-  ac_format B1 = "%opcd:6 %bo:5 %bi:5 %bd:14:s %aa:1 %lk:1";
+  ac_format B1 = "%opcd:6 %bo:5 %bi_cf:3 %bi_cb:2 %bd:14:s %aa:1 %lk:1";
 
   ac_format SC1 = "%opcd:6 0x00:5 0x00:5 0x00:4 %lev:7 0x00:3 0x01:1 0x00:1";
 
@@ -201,7 +201,7 @@ AC_ISA(powerpc) {
 
   ac_asm_map reg {
     /* default gas assembler uses numbers as register names */
-    ""[0..31] = [0..31];           
+    ""[0..31] = [0..31];
   }
 
   ac_asm_map trapcond {
@@ -227,6 +227,9 @@ AC_ISA(powerpc) {
     "l" = 1;
   }
 
+  ac_asm_map ccr {
+    "cr"[0..7] = [0..7];
+  }
 
   ISA_CTOR(powerpc) {
 
@@ -372,7 +375,7 @@ AC_ISA(powerpc) {
     bla.set_decoder(opcd=18, aa=1, lk=1);
     bla.set_cycles(1); 
     
-    bc.set_asm("bc%[lk]%[aa] %imm, %exp, %addr(pcrel)", lk, aa, bo, bi, bd);
+    bc.set_asm("bc%[lk]%[aa] %imm, %exp, %addr(pcrel)", lk, aa, bo, bi_cb+bi_cf, bd);
     bc.set_decoder(opcd=16);
     bc.set_cycles(1); 
 
@@ -1193,6 +1196,69 @@ AC_ISA(powerpc) {
     twi.set_decoder(opcd=3);
     twi.set_cycles(1);
 
+    /*
+     * See Power ISA Version 3.1B, sections:
+     *  - C.2.3 Branch Mnemonics Incorporating Conditions
+     *  - 2.3.1 Condition Register
+     *
+     * Condition bits (bi_cg bitfield):
+     *
+     *  0...LT (The result is negative)
+     *  1...GT (The result is positive)
+     *  2...EQ (The result is zero)
+     *  3...SO (Summary Overflow)
+     *
+     * Condition under which is branch taken (bo bitfield)
+     *
+     * 0000z       Decrement the CTR, then branch if the decremented CTRM:63!=0 and CRBI=0
+     * 0001z       Decrement the CTR, then branch if the decremented CTRM:63=0 and CRBI=0
+     * 001at =0x4  Branch if CRBI=0
+     * 0100z       Decrement the CTR, then branch if the decremented CTRM:63!=0 and CRBI=1
+     * 0101z       Decrement the CTR, then branch if the decremented CTRM:63=0 and CRBI=1
+     * 011at =0xC  Branch if CRBI=1
+     * 1a00t       Decrement the CTR, then branch if the decremented CTRM:63≠0
+     * 1a01t       Decrement the CTR, then branch if the decremented CTRM:63=0
+     * 1z1zz       Branch always
+     *
+     * at=00 means no hint given
+     * z=0   should be ignored but some code expect it to be zero.
+     */
+
+     bc.set_asm("blt%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=0, bo=0xC);
+     bc.set_asm("blt%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=0, bo=0xC);
+
+     bc.set_asm("ble%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=1, bo=0x4);
+     bc.set_asm("ble%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=1, bo=0x4);
+
+     bc.set_asm("beq%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=2, bo=0xC);
+     bc.set_asm("beq%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=2, bo=0xC);
+
+     bc.set_asm("bge%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=0, bo=0x4);
+     bc.set_asm("bge%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=0, bo=0x4);
+
+     bc.set_asm("bgt%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=1, bo=0xC);
+     bc.set_asm("bgt%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=1, bo=0xC);
+
+     /* Following are here for completeness but commented out
+      * as in disassembly we prefer `bge` over `bnl`.
+      */
+     //bc.set_asm("bnl%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=0, bo=0x4);
+     //bc.set_asm("bnl%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=0, bo=0x4);
+
+     bc.set_asm("bne%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=2, bo=0x4);
+     bc.set_asm("bne%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=2, bo=0x4);
+
+     /* Following are here for completeness but commented out
+      * as in disassembly we prefer `ble` over `bng`.
+      */
+     //bc.set_asm("bng%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=1, bo=0x4);
+     //bc.set_asm("bng%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=1, bo=0x4);
+
+     bc.set_asm("bso%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=3, bo=0xC);
+     bc.set_asm("bso%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=3, bo=0xC);
+
+     bc.set_asm("bns%[lk]%[aa] %addr(pcrel)",       lk, aa, bd, bi_cf=0, bi_cb=3, bo=0x4);
+     bc.set_asm("bns%[lk]%[aa] %ccr, %addr(pcrel)", lk, aa, bi_cf, bd,   bi_cb=3, bo=0x4);
 
 /*******************************************************/
 /* Optional properties to optimize compiled simulation */
@@ -1259,31 +1325,6 @@ AC_ISA(powerpc) {
     pseudo_instr("slwi %reg, %reg, %imm") {
       "rlwinm %0, %1, %2, 0, 31-%2";
     }
-
-    pseudo_instr("ble %imm, %addr") {
-      "bc 0x4, %0*4+1, %1";
-    }
-
-    pseudo_instr("bne %imm, %addr") {
-      "bc 0x4, %0*4+2, %1";
-    }
-
-    pseudo_instr("bgt %imm, %addr") {
-      "bc 0xC, %0*4+1, %1";
-    }
-
-    pseudo_instr("blt %imm, %addr") {
-      "bc 0xC, %0*4, %1";
-    }
-
-    pseudo_instr("bge %imm, %addr") {
-      "bc 0x4, %0*4, %1";
-    }
-
-    pseudo_instr("beq %imm, %addr") {
-      "bc 0xC, %0*4+2, %1";
-    }
-
   };
 
 };


### PR DESCRIPTION
This PR add support for powerpc64 and for conditional branch mnemonics incorporating conditions (`bne` and so on). It requires corresponing changes in ArchC, see https://github.com/shingarov/Pharo-ArchC/pull/25.